### PR TITLE
Fix example in documents in callback.rst

### DIFF
--- a/docs/callback.rst
+++ b/docs/callback.rst
@@ -29,7 +29,7 @@ initialization.
 .. testcode::
 
     from kafka import KafkaConsumer
-    from kq import Worker
+    from kq import Worker, Job
 
 
     def callback(status, message, job, result, exception, stacktrace):


### PR DESCRIPTION
Callback example is missing a Job import in order to work correctly.

Although this is trivial, I think it should be corrected